### PR TITLE
Add FantasySync swipe deck feature

### DIFF
--- a/app/src/main/java/com/erzi/fantasysync/swipe/data/SwipeRepository.kt
+++ b/app/src/main/java/com/erzi/fantasysync/swipe/data/SwipeRepository.kt
@@ -1,0 +1,31 @@
+package com.erzi.fantasysync.swipe.data
+
+import com.erzi.fantasysync.swipe.model.FantasyCard
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Provides access to swipe deck data.
+ */
+interface SwipeRepository {
+    /** Flow of cards currently in the deck. */
+    val cards: Flow<List<FantasyCard>>
+
+    /**
+     * Removes the given card from the deck.
+     */
+    suspend fun swipe(card: FantasyCard)
+}
+
+/**
+ * Simple in-memory implementation of [SwipeRepository].
+ */
+class InMemorySwipeRepository(initialCards: List<FantasyCard>) : SwipeRepository {
+    private val _cards = MutableStateFlow(initialCards)
+    override val cards: Flow<List<FantasyCard>> = _cards
+
+    override suspend fun swipe(card: FantasyCard) {
+        _cards.update { list -> list.filter { it.id != card.id } }
+    }
+}

--- a/app/src/main/java/com/erzi/fantasysync/swipe/model/FantasyCard.kt
+++ b/app/src/main/java/com/erzi/fantasysync/swipe/model/FantasyCard.kt
@@ -1,0 +1,10 @@
+package com.erzi.fantasysync.swipe.model
+
+/**
+ * Represents a single item displayed in the swipe deck.
+ */
+data class FantasyCard(
+    val id: String,
+    val title: String,
+    val description: String
+)

--- a/app/src/main/java/com/erzi/fantasysync/swipe/ui/SwipeDeckScreen.kt
+++ b/app/src/main/java/com/erzi/fantasysync/swipe/ui/SwipeDeckScreen.kt
@@ -1,0 +1,66 @@
+package com.erzi.fantasysync.swipe.ui
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.consume
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.erzi.fantasysync.swipe.model.FantasyCard
+import com.erzi.fantasysync.swipe.viewmodel.SwipeViewModel
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+@Composable
+fun SwipeDeckScreen(viewModel: SwipeViewModel) {
+    val cards by viewModel.cards.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        cards.asReversed().forEach { card ->
+            SwipeableCard(card = card, onSwiped = { viewModel.swipe(card) })
+        }
+    }
+}
+
+@Composable
+private fun SwipeableCard(card: FantasyCard, onSwiped: () -> Unit) {
+    var offsetX by remember { mutableStateOf(0f) }
+    val threshold = 150f
+
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(offsetX.roundToInt(), 0) }
+            .pointerInput(card.id) {
+                detectDragGestures(
+                    onDragEnd = {
+                        if (abs(offsetX) > threshold) onSwiped()
+                        offsetX = 0f
+                    }
+                ) { change, dragAmount ->
+                    change.consume()
+                    offsetX += dragAmount.x
+                }
+            }
+    ) {
+        Card(elevation = 8.dp) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(text = card.title, style = MaterialTheme.typography.h6, fontSize = 20.sp)
+                Text(text = card.description)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/erzi/fantasysync/swipe/viewmodel/SwipeViewModel.kt
+++ b/app/src/main/java/com/erzi/fantasysync/swipe/viewmodel/SwipeViewModel.kt
@@ -1,0 +1,31 @@
+package com.erzi.fantasysync.swipe.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.erzi.fantasysync.swipe.data.SwipeRepository
+import com.erzi.fantasysync.swipe.model.FantasyCard
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the swipe deck screen.
+ */
+class SwipeViewModel(private val repository: SwipeRepository) : ViewModel() {
+
+    /**
+     * Exposes the current cards as a [StateFlow] for UI consumption.
+     */
+    val cards: StateFlow<List<FantasyCard>> = repository.cards
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /**
+     * Handles a swipe event on [card].
+     */
+    fun swipe(card: FantasyCard) {
+        viewModelScope.launch {
+            repository.swipe(card)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add FantasyCard model
- add SwipeRepository with in-memory implementation
- add SwipeViewModel exposing swipe deck state
- add SwipeDeckScreen compose UI with swipe gestures

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68465574b60c8328adbfa9f64fca0054