### PR TITLE
Add advanced prompt builder with model search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Studio‑grade mastering • Zero local setup • Built by **Erzi Solutions*
 | **Workflow Library** | Pre‑built pipelines: **Podcast**, **Livestream**, **Game Audio**, **Genre Morph**, **Stem Master** |
 | **REST API & CLI** | FastAPI server + Python CLI (`launcher.py`) for automation |
 | **Gradio / HTML GUI** | Drag‑&‑drop web interface with A↔B “Normal vs Enchanted” toggle |
+| **Advanced Prompt Builder** | Deep search & model-selection interface |
 | **Docker & CI/CD** | One‑command container, GitHub Actions for lint + pytest |
 | **MKDocs Docs Site** | Full developer & user manuals ready for GitHub Pages |
 
@@ -66,7 +67,7 @@ Studio‑grade mastering • Zero local setup • Built by **Erzi Solutions*
 ```
 ├── launcher.py               # Simple CLI launcher
 ├── api_server.py             # FastAPI backend
-├── webapp/                   # Gradio & static HTML GUI
+├── webapp/                   # Gradio & static HTML GUI + advanced prompt builder
 ├── workflows/                # Modular processing pipelines
 ├── analysis/                 # QA engine & audio analyzers
 ├── restoration/              # Noise/hiss repair modules

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ OMNI-CODEX is an AI-driven audio mastering and restoration platform with modular
 ### Components
 - **api_server.py** – Flask REST API (POST /master, GET /status)
 - **webapp/web_interface.html** – simple HTML/JS frontend that uses the API
+- **webapp/logical_advocate.html** – advanced prompt builder with model search
 - **gui.py** – Streamlit desktop GUI
 - **launcher.py** – CLI menu
 - **workflows/** – individual mastering workflows

--- a/docs/run.md
+++ b/docs/run.md
@@ -20,4 +20,4 @@ python launcher.py
 
 ## Web Interfejs
 
-Otvorite lokalni fajl `webapp/web_interface.html` u pretraživaču.
+Otvorite lokalni fajl `webapp/web_interface.html` ili novu stranicu `webapp/logical_advocate.html` u pretraživaču.

--- a/webapp/logical_advocate.html
+++ b/webapp/logical_advocate.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logical Advocate Advanced</title>
+    <style>
+        body {font-family: Arial, Helvetica, sans-serif;background:#111;color:#eee;margin:0;padding:20px;}
+        h1 {text-align:center;margin-bottom:20px;}
+        .form-group{margin-bottom:15px;}
+        label{display:block;margin-bottom:5px;font-weight:bold;}
+        input,textarea,select{width:100%;padding:8px;border-radius:4px;border:1px solid #555;background:#222;color:#eee;}
+        button{padding:10px 20px;border:none;border-radius:4px;background:#4caf50;color:white;cursor:pointer;margin-right:10px;}
+        #results{margin-top:20px;padding:10px;border:1px solid #555;background:#222;white-space:pre-wrap;}
+    </style>
+</head>
+<body>
+<h1>Logical Advocate Advanced</h1>
+<div class="form-group">
+    <label for="content">Content</label>
+    <textarea id="content" rows="6" placeholder="Enter your text..."></textarea>
+</div>
+<div class="form-group">
+    <label for="objective">Objective</label>
+    <input id="objective" type="text" placeholder="e.g. business plan" />
+</div>
+<div class="form-group">
+    <label for="model">Model Version</label>
+    <select id="model">
+        <option value="gpt-3.5">GPT‑3.5</option>
+        <option value="gpt-4">GPT‑4</option>
+        <option value="gpt-4.5">GPT‑4.5</option>
+    </select>
+</div>
+<div class="form-group">
+    <label for="depth">Research Depth</label>
+    <select id="depth">
+        <option value="basic">Basic</option>
+        <option value="deep">Deep Search</option>
+    </select>
+</div>
+<div class="form-group">
+    <label for="pages">Target Page Length</label>
+    <input id="pages" type="number" min="1" max="100" value="1" />
+</div>
+<div class="form-group">
+    <label for="promptTemplate">Prompt Library</label>
+    <select id="promptTemplate"></select>
+</div>
+<button id="generate">Generate Prompt</button>
+<button id="copy">Copy</button>
+<div id="results"></div>
+<script>
+async function loadPrompts(){
+    try{
+        const resp = await fetch('prompts.json');
+        const data = await resp.json();
+        const sel = document.getElementById('promptTemplate');
+        const defaultOpt = document.createElement('option');
+        defaultOpt.value = '';
+        defaultOpt.textContent = 'Select template…';
+        sel.appendChild(defaultOpt);
+        data.forEach(p=>{
+            const opt=document.createElement('option');
+            opt.value=p.prompt;
+            opt.textContent=p.name;
+            sel.appendChild(opt);
+        });
+    }catch(e){console.error(e);}
+}
+loadPrompts();
+
+document.getElementById('promptTemplate').addEventListener('change',e=>{
+    const val=e.target.value;
+    if(val){document.getElementById('content').value=val;}
+});
+
+function buildPrompt(){
+    const content=document.getElementById('content').value.trim();
+    const objective=document.getElementById('objective').value.trim();
+    const model=document.getElementById('model').value;
+    const depth=document.getElementById('depth').value;
+    const pages=document.getElementById('pages').value;
+    return `Model: ${model}\nDepth: ${depth}\nPages: ${pages}\nObjective: ${objective}\n---\n${content}`;
+}
+
+document.getElementById('generate').addEventListener('click',()=>{
+    const prompt=buildPrompt();
+    document.getElementById('results').textContent=prompt;
+});
+
+document.getElementById('copy').addEventListener('click',async()=>{
+    const txt=document.getElementById('results').textContent;
+    try{await navigator.clipboard.writeText(txt);}catch(e){alert('copy failed');}
+});
+</script>
+</body>
+</html>

--- a/webapp/prompts.json
+++ b/webapp/prompts.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Business Strategy",
+    "prompt": "Draft a comprehensive business strategy for a tech startup."
+  },
+  {
+    "name": "Technical Guide",
+    "prompt": "Write a step-by-step technical guide for setting up a cloud server."
+  }
+]


### PR DESCRIPTION
## Summary
- introduce `webapp/logical_advocate.html` advanced prompt builder
- load templates from `webapp/prompts.json`
- reference new interface in docs
- fix newline in docs/run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855e52a0a508328a470718515d6a94f